### PR TITLE
Add custom import groups and fix relative order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   plugins: ["import", "jest", "prettier"],
   env: { es6: true, node: true },
   rules: Object.assign({}, baseRules({ import: true }), {
-    "import/order": ["error", { "newlines-between": "always" }],
+    "import/newline-after-import": "error",
     "no-console": "error",
     "prefer-template": "off",
     "prettier/prettier": "error",

--- a/examples/readme-order.js
+++ b/examples/readme-order.js
@@ -8,6 +8,9 @@ import type A from "an-npm-package";
 import a from "an-npm-package";
 import fs from "fs";
 
+// Private packages.
+import { Row } from "@margobank/components/layout";
+
 // Absolute imports, full URLs and other imports.
 import b from "https://example.com/script.js";
 import Error from "@/components/error.vue"
@@ -15,14 +18,14 @@ import c from "/";
 import d from "/home/user/foo";
 
 // Relative imports.
-import e from "../..";
 import f from "../../Utils"; // Case insensitive.
+import e from "../..";
 import type { B } from "../types";
 import typeof C from "../types";
-import g from ".";
 import h from "./constants";
 import i from "./styles";
 import j from "html-loader!./text.html";
+import g from ".";
 
 // Regardless of group, imported items are sorted like this:
 import {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 "use strict";
 
-const sort = require("./sort");
-
 module.exports = {
   rules: {
-    sort,
+    "sort-imports": require("./sort"),
   },
 };

--- a/src/sort.js
+++ b/src/sort.js
@@ -740,9 +740,15 @@ function getTrailingSpaces(node, sourceCode) {
   return lines[0];
 }
 
+function ensureReactIsFirst(a, b) {
+  return a === "react" ? -1 : b === "react" ? 1 : 0;
+}
+
 function sortImportItems(items) {
   return items.slice().sort(
     (itemA, itemB) =>
+      // If source is 'react', put it first!
+      ensureReactIsFirst(itemA.source.source, itemB.source.source) ||
       // First compare the `from` part, excluding webpack loader syntax.
       compare(itemA.source.source, itemB.source.source) ||
       // The `.source` has been slightly tweaked. To stay fully deterministic,

--- a/src/sort.js
+++ b/src/sort.js
@@ -769,11 +769,11 @@ function sortSpecifierItems(items) {
   return items.slice().sort(
     (itemA, itemB) =>
       // Put Flow type imports before regular ones.
-      compare(getImportKind(itemA.node), getImportKind(itemB.node)) ||
+      compare(getImportKind(itemA.node), getImportKind(itemB.node), true) ||
       // Then compare by name.
-      compare(itemA.node.imported.name, itemB.node.imported.name) ||
+      compare(itemA.node.imported.name, itemB.node.imported.name, true) ||
       // Then compare by the `as` name.
-      compare(itemA.node.local.name, itemB.node.local.name) ||
+      compare(itemA.node.local.name, itemB.node.local.name, true) ||
       // Keep the original order if the names are the same. It's not worth
       // trying to compare anything else, `import {a, a} from "mod"` is a syntax
       // error anyway (but babel-eslint kind of supports it).
@@ -784,8 +784,10 @@ function sortSpecifierItems(items) {
 
 // We don't use Intl.Collator here to preserve the natural order of special chars.
 // In particular, we wan't '_' to be after '.'.
-function compare(a, b) {
-  return a < b ? -1 : a > b ? 1 : 0;
+function compare(a, b, caseSensitive = false) {
+  const aToCompare = caseSensitive ? a : a.toLowerCase();
+  const bToCompare = caseSensitive ? b : b.toLowerCase();
+  return aToCompare < bToCompare ? -1 : aToCompare > bToCompare ? 1 : 0;
 }
 
 // Return child directories of `moduleRoots` defined in package.json

--- a/src/sort.js
+++ b/src/sort.js
@@ -72,6 +72,7 @@ function maybeReportSorting(imports, context) {
 function printSortedImports(importItems, sourceCode) {
   const sideEffectImports = [];
   const packageImports = [];
+  const privatePackageImports = [];
   const relativeImports = [];
   const restImports = [];
 
@@ -80,6 +81,8 @@ function printSortedImports(importItems, sourceCode) {
       sideEffectImports.push(item);
     } else if (item.group === "package") {
       packageImports.push(item);
+    } else if (item.group === "privatePackage") {
+      privatePackageImports.push(item);
     } else if (item.group === "relative") {
       relativeImports.push(item);
     } else {
@@ -90,6 +93,7 @@ function printSortedImports(importItems, sourceCode) {
   const sortedItems = [
     sideEffectImports,
     sortImportItems(packageImports),
+    sortImportItems(privatePackageImports),
     sortImportItems(restImports),
     sortImportItems(relativeImports),
   ];
@@ -812,6 +816,14 @@ function isPackageImport(source) {
   );
 }
 
+const PRIVATE_PACKAGE_REGEX = /^@margobank\/components.+/;
+
+// import { PrimaryButton } from "@margobank/components/button";
+// import { Row } from "@margobank/components/layout";
+function isPrivatePackageImport(source) {
+  return PRIVATE_PACKAGE_REGEX.test(source);
+}
+
 // import a from "."
 // import a from "./x"
 // import a from ".."
@@ -863,6 +875,8 @@ function getGroupAndSource(importNode, sourceCode) {
       : [rawSource, ""];
   const group = isSideEffectImport(importNode, sourceCode)
     ? "sideEffect"
+    : isPrivatePackageImport(source)
+    ? "privatePackage"
     : isPackageImport(source)
     ? "package"
     : isRelativeImport(source)

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -191,9 +191,9 @@ import {/* comment at start */ f, /* f */g/* g */ } from "wherever3";
 `;
 
 exports[`examples readme-example.js 1`] = `
+import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
 
 import { getUser } from "../../api";
 import type { User } from "../../types";
@@ -214,18 +214,20 @@ import type A from "an-npm-package";
 import a from "an-npm-package";
 import fs from "fs";
 
-// Absolute imports, full URLs and other imports.
-import b from "https://example.com/script.js";
-import Error from "@/components/error.vue";
+// Private packages.
+import { Row } from "@margobank/components/layout";
+
 import c from "/";
 import d from "/home/user/foo";
+import Error from "@/components/error.vue";
+// Absolute imports, full URLs and other imports.
+import b from "https://example.com/script.js";
 
 // Relative imports.
-import e from "../..";
 import f from "../../Utils"; // Case insensitive.
+import e from "../..";
 import type { B } from "../types";
 import typeof C from "../types";
-import g from ".";
 import h from "./constants";
 import i from "./styles";
 import j from "html-loader!./text.html";
@@ -234,24 +236,25 @@ import {
   // First, Flow type imports.
   type x,
   typeof y,
+  L, // Case insensitive.
   // Numbers are sorted by their numeric value:
   img1,
-  img2,
   img10,
+  img2,
   // Then everything else, alphabetically:
   k,
-  L, // Case insensitive.
   m as anotherName, // Sorted by the original name “m”, not “anotherName”.
   m as tie, // But do use the \`as\` name in case of a tie.
   n,
 } from "./x";
+import g from ".";
 
 `;
 
 exports[`examples typescript.ts 1`] = `
+import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
 
 import { getUser } from "../../api";
 import { formatNumber,truncate } from "../../utils";

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -122,6 +122,16 @@ const baseTests = expect => ({
           |import b from "b";    
           |import c from "c";  /* comment */  
     `,
+
+    // Private packages are grouped together
+    input`
+          |import a from "a"
+          |
+          |import { Field } from "@margobank/components/form";
+          |import { Row } from "@margobank/components/layout";
+          |
+          |import b from "./b";
+    `,
   ],
 
   invalid: [
@@ -319,23 +329,23 @@ const baseTests = expect => ({
         expect(actual).toMatchInlineSnapshot(`
           |import {
           |  A,
-          |  a,
-          |  ab,
           |  B,
-          |  b,
           |  B2,
           |  BA,
-          |  Ba,
-          |  bA,
-          |  ba,
           |  BB,
+          |  Ba,
           |  Bb,
+          |  a,
+          |  ab,
+          |  b,
+          |  bA,
           |  bB,
+          |  ba,
           |  bb,
           |  img1,
-          |  img2,
           |  img10,
           |  img10_black,
+          |  img2,
           |  x as C,
           |  x as d,
           |} from "specifiers-human-sort"
@@ -902,59 +912,59 @@ const baseTests = expect => ({
       `,
       output: actual => {
         expect(actual).toMatchInlineSnapshot(`
+          |import {} from "react";
+          |import {} from "1";
           |import {} from "@storybook/react";
           |import {} from "@storybook/react/something";
-          |import {} from "1";
           |import {} from "async";
           |import {} from "fs";
           |import {} from "fs/something";
           |import {} from "lodash/fp";
-          |import {} from "react";
           |
           |import {} from "";
+          |import {} from "#/test"
+          |import {} from "...";
+          |import {} from ".../";
+          |import {} from ".a";
+          |import {} from "/";
+          |import {} from "/a";
+          |import {} from "/a/b";
           |import {} from "1*";
+          |import {} from "@/components/Alert"
+          |import {} from "@/components/error.vue"
           |import {} from "a*";
           |import {} from "Fs";
           |import {} from "http://example.com/script.js";
           |import {} from "https://example.com/script.js";
-          |import {} from "...";
-          |import {} from ".../";
-          |import {} from ".a";
-          |import {} from "@/components/Alert"
-          |import {} from "@/components/error.vue"
-          |import {} from "/";
-          |import {} from "/a";
-          |import {} from "/a/b";
-          |import {} from "#/test"
           |import {} from "~/test"
           |
-          |import {} from "..";
-          |import {} from "../";
-          |import {} from "../..";
-          |import {} from "../../";
           |import {} from "../../a";
+          |import {} from "../../";
+          |import {} from "../..";
           |import {} from "../a";
-          |import {} from "../a/..";
           |import {} from "../a/...";
-          |import {} from "../a/../";
           |import {} from "../a/../b";
-          |import {} from ".";
-          |import {} from "loader!.";
-          |import {} from "./";
+          |import {} from "../a/../";
+          |import {} from "../a/..";
+          |import {} from "../";
+          |import {} from "..";
           |import {} from ".//";
           |import {} from "./A";
           |import {} from "./a";
-          |import {} from "./ä"; // “a” followed by “̈̈” (COMBINING DIAERESIS).
-          |import {} from "./ä";
           |import {} from "./a/-";
           |import {} from "./a/.";
           |import {} from "./a/0";
+          |import {} from "./ä"; // “a” followed by “̈̈” (COMBINING DIAERESIS).
           |import {} from "./B"; // B1
-          |import {} from "./B"; // B2
           |import {} from "./b";
+          |import {} from "./B"; // B2
           |import img1 from "./img1";
-          |import img2 from "./img2";
           |import img10 from "./img10";
+          |import img2 from "./img2";
+          |import {} from "./";
+          |import {} from "./ä";
+          |import {} from ".";
+          |import {} from "loader!.";
         `);
       },
       errors: 1,
@@ -1364,7 +1374,7 @@ const baseTests = expect => ({
       `,
       output: actual => {
         expect(actual).toMatchInlineSnapshot(`
-          |import { buttonPrimary, linkButton, Select, spinnerOverlay } from 'src/components/common'
+          |import { Select, buttonPrimary, linkButton, spinnerOverlay } from 'src/components/common'
           |import DataTable from 'src/components/DataTable'
           |import ExportDataModal from 'src/components/ExportDataModal'
           |import FloatingActionButton from 'src/components/FloatingActionButton'
@@ -1459,6 +1469,31 @@ const baseTests = expect => ({
       },
       errors: 1,
     },
+
+    // Group private packages together.
+    {
+      code: input`
+          |import { Row } from "@margobank/components/layout";
+          |import c from "./c";
+          |import x2 from "b"
+          |import { Field } from "@margobank/components/form";
+          |import a from "a"
+          |import x1 from "a";
+      `,
+      output: actual => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import a from "a"
+          |import x1 from "a";
+          |import x2 from "b"
+          |
+          |import { Field } from "@margobank/components/form";
+          |import { Row } from "@margobank/components/layout";
+          |
+          |import c from "./c";
+        `);
+      },
+      errors: 1,
+    },
   ],
 });
 
@@ -1517,11 +1552,11 @@ const flowTests = {
           |
           |import react from "react"
           |
+          |import type C from "/B";
+          |import type E from "@/B";
           |import typeof A from "A";
           |import type {X} from "X";
           |import type {Z} from "Z";
-          |import type E from "@/B";
-          |import type C from "/B";
           |
           |import type B from "./B";
           |import typeof D from "./D";
@@ -1715,9 +1750,9 @@ const typescriptTests = {
       `,
       output: actual => {
         expect(actual).toMatchInlineSnapshot(`
+          |import React from "react";
           |import classnames from "classnames";
           |import PropTypes from "prop-types";
-          |import React from "react";
           |
           |import { getUser } from "../../api";
           |import { formatNumber,truncate } from "../../utils";
@@ -1755,14 +1790,20 @@ const expect2 = (...args) => {
     ret.toBe(strip(string, { keepPipes: true }));
   return ret;
 };
-javascriptRuleTester.run("JavaScript", plugin.rules.sort, baseTests(expect));
-flowRuleTester.run("Flow", plugin.rules.sort, baseTests(expect2));
-typescriptRuleTester.run("TypeScript", plugin.rules.sort, baseTests(expect2));
-
-flowRuleTester.run("Flow-specific", plugin.rules.sort, flowTests);
-
+javascriptRuleTester.run(
+  "JavaScript",
+  plugin.rules["sort-imports"],
+  baseTests(expect)
+);
+flowRuleTester.run("Flow", plugin.rules["sort-imports"], baseTests(expect2));
+typescriptRuleTester.run(
+  "TypeScript",
+  plugin.rules["sort-imports"],
+  baseTests(expect2)
+);
+flowRuleTester.run("Flow-specific", plugin.rules["sort-imports"], flowTests);
 typescriptRuleTester.run(
   "TypeScript-specific",
-  plugin.rules.sort,
+  plugin.rules["sort-imports"],
   typescriptTests
 );


### PR DESCRIPTION
This PR does several things:
- it adds a new group for  **Private packages** (starting by `@margobank/components`); 
- it adds a new group for **Internal packages** (directories having `moduleRoots` as parent, if defined in `package.json`);
- it sets **React** imports first in external packages;
- it changes the way **Relative** imports are sorted (`../../` now comes before `../` and `./_parts` before `./`).

**Drawback:**
As we removed the usage of `Intl.Collator` to fix the relative imports sorting, integers won't be sorted naturally anymore. (`./Component10` would come before `./Component2`) 😞 

Imports are now sorted as follow:

```js
// Side effect imports. (These are not sorted internally.)
import "some-polyfill";
import "./global.css";

// Packages. (With React always first.)
import { useEffect } from "react";
import a from "an-npm-package";
import fs from "fs";

// Private packages. (Only from @margobank/components.)
import { Field } from "@margobank/components/form";
import { Row } from "@margobank/components/layout";

// Internal packages. (If `moduleRoots` is defined in package.json.)
import { SESSION_DURATION_MS } from "app/auth";
import Login from "app/auth/Login";
import { DEFAULT_LOCALE } from "common/constants";

// Absolute imports, full URLs and other imports.
import b from "/";
import c from "/home/user/foo";

// Relative imports.
import { Z, someUtility } from "../../utils";
import d from "../..";
import Component1 from "../Component1";
import Component10 from "../Component10"; // :(
import Component2 from "../Component2";
import { A, B } from "../types";
import { C } from "./_parts";
import { D } from "./_styled";
import e from "./styles";
import f from "html-loader!./text.html";
import g from ".";
```